### PR TITLE
chore: Remover Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-


### PR DESCRIPTION
## Resumo
- Remove a configuração do Dependabot para evitar PRs automáticos.

## Mudanças
- Remove .github/dependabot.yml


Made with [Cursor](https://cursor.com)